### PR TITLE
Some niceties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,18 +24,22 @@ Categories are:
 - Special blocks are now supported in core (#7)
 - md4c-reader: special blocks can themselves include Markdown (#23)
 
+### Fixed
+
+- pango-markup: Consecutive headers have whitespace between them (#29)
+
 ## [0.0.5] - 2020-11-21
 
 ### Added
 
-- Any image in a paragraph by itself, with a caption, will be rendered as a centered figure with that caption (#22)
-- Accept GitHub-flavored Markdown and underlines.  Now `*italics*` and `_underline_`, instead of `_italics_`.
+- pango-markup: Any image in a paragraph by itself, with a caption, will be rendered as a centered figure with that caption (#22)
+- md4c-reader: Accept GitHub-flavored Markdown and underlines.  Now `*italics*` and `_underline_`, instead of `_italics_`.
 - (DEV) Can now generate Debian packages (#12)
 
 ### Changed
 
-- 12-point fonts are actually 12 points now (they were larger before) (8cbb1be5a221168bab6f48dc98d06af53d6cc3a5)
-- Code blocks now have light-gray backgrounds so they stand out more (#3)
+- pango-markup: 12-point fonts are actually 12 points now (they were larger before) (8cbb1be5a221168bab6f48dc98d06af53d6cc3a5)
+- pango-markup: Code blocks now have light-gray backgrounds so they stand out more (#3)
 - (DEV) Minimum valac now 0.48
   - Use valac from the [Vala Next PPA](https://launchpad.net/~vala-team/+archive/ubuntu/next) on Travis
 
@@ -48,7 +52,7 @@ Categories are:
 
 ### Changed
 
-- Paragraphs of body text now have whitespace between them.
+- pango-markup: Paragraphs of body text now have whitespace between them.
 
 ## [0.0.3] - 2020-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-# Changelog
+# Changelog for pfft
 
-All notable changes to this project will be documented in this file.
+All notable changes to the [pfft] lightweight Markdown-to-PDF converter will be
+documented in this file.
 
-The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format of this changelog is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 The notation "(DEV)" marks changes of interest primarily to developers
 as opposed to users.
@@ -17,15 +19,19 @@ Categories are:
 - "Fixed": bug fixes.
 - "Security": updates fixing vulnerabilities.
 
-## [Unreleased]
+## [0.0.6] - 2020-12-06
 
 ### Added
 
+- This file!
 - Special blocks are now supported in core (#7)
 - md4c-reader: special blocks can themselves include Markdown (#23)
+- You can now use HTML comments in your Markdown files --- md4c-reader
+  and pango-markup cooperate to remove those comments from the output (#28)
 
 ### Fixed
 
+- pango-markup: Code blocks within bulleted or numbered lists are indented
 - pango-markup: Consecutive headers have whitespace between them (#29)
 
 ## [0.0.5] - 2020-11-21
@@ -33,7 +39,7 @@ Categories are:
 ### Added
 
 - pango-markup: Any image in a paragraph by itself, with a caption, will be rendered as a centered figure with that caption (#22)
-- md4c-reader: Accept GitHub-flavored Markdown and underlines.  Now `*italics*` and `_underline_`, instead of `_italics_`.
+- md4c-reader: Accept GitHub-flavored Markdown and underlines.  Now `*italics*` and `_underline_`, instead of `_italics_`
 - (DEV) Can now generate Debian packages (#12)
 
 ### Changed
@@ -52,14 +58,14 @@ Categories are:
 
 ### Changed
 
-- pango-markup: Paragraphs of body text now have whitespace between them.
+- pango-markup: Paragraphs of body text now have whitespace between them
 
 ## [0.0.3] - 2020-09-26
 
 ### Added
 
 - You can now set the font size
-- You can use dimensions in templates, e.g., `210mm` instead of `8.2677` (inches).
+- You can use dimensions in templates, e.g., `210mm` instead of `8.2677` (inches)
 
 ### Changed
 
@@ -87,9 +93,12 @@ Categories are:
 - Read Markdown files containing headers, code blocks, images, lists
 - Render PDFs
 
-[Unreleased]: https://github.com/cxw42/pfft/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/cxw42/pfft/compare/v0.0.6...HEAD
+[0.0.6]: https://github.com/cxw42/pfft/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/cxw42/pfft/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/cxw42/pfft/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/cxw42/pfft/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/cxw42/pfft/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/cxw42/pfft/compare/cc7632e090218a32fb631734d1eb0e39adfdf173...v0.0.1
+
+[pfft]: https://github.com/cxw42/pfft

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,10 @@ This will build `pfft-VERSION.tar.gz` and check it.
 PRs are welcome!  I prefer PRs with one commit that adds tests and a subsequent
 commit that adds the code (TDD).  However, that is not required.
 
+With the commit that adds the code, please also include an update to
+[CHANGELOG.md](CHANGELOG.md) describing the change in the "Unreleased"
+section.
+
 Before submitting a PR, please run `make prep`.  This will:
 
 - `make prettyprint` (conform to the coding style)
@@ -120,4 +124,3 @@ Before submitting a PR, please run `make prep`.  This will:
 ## Other notes
 
 - All files are UTF-8, no BOM.
-

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl === Basic setup =======================================================
-AC_INIT([pfft markdown-to-PDF converter], [0.0.5], [], [pfft], [https://github.com/cxw42/pfft])
+AC_INIT([pfft markdown-to-PDF converter], [0.0.6], [], [pfft], [https://github.com/cxw42/pfft])
 AC_PREREQ([2.65])
 AC_COPYRIGHT([Copyright (C) 2020 Christopher White])
 AC_CONFIG_SRCDIR([rules.mk])    dnl make sure the srcdir is correctly specified

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-pfft (0.0.5-1) UNRELEASED; urgency=medium
+pfft (0.0.6-1) UNRELEASED; urgency=medium
+
+  * 
+
+ -- Christopher White <cxwembedded@gmail.com>  Sun, 22 Nov 2020 18:54:42 -0500
+
+pfft (0.0.5-1) unstable; urgency=medium
 
   * First version to be packaged as a deb
 

--- a/src/core/el.vala
+++ b/src/core/el.vala
@@ -7,6 +7,10 @@
  */
 namespace My {
 
+    // Known info strings for special blocks
+    public const string INFOSTR_HTML = "html";
+    public const string INFOSTR_NOP = "nop";
+
     /**
      * Our own definition for gst_value_deserialize().
      *

--- a/src/writer/pango-markup.vala
+++ b/src/writer/pango-markup.vala
@@ -777,11 +777,17 @@ namespace My {
                 blk.markup._chomp();
             }
 
-            // TODO move command parsing into core, and just respond to cmds here
+            // Respond to commands from special blocks
             switch(cmd) {
             case "":
                 // not a command
                 break;
+
+            case INFOSTR_NOP:   // Drop the block
+                blk = new ParaBlk(layout_);
+                complete = true;
+                break;
+
             default:
                 lwarningo(this, "Ignoring unknown command '%s'", cmd);
                 break;

--- a/src/writer/pango-markup.vala
+++ b/src/writer/pango-markup.vala
@@ -257,7 +257,7 @@ namespace My {
 
                     if(!first_on_page_ && prev_blk != null &&
                         ( blk.parskip_category == COPY ||
-                          blk.parskip_category == HEADER ||
+                        blk.parskip_category == HEADER ||
                         prev_blk.parskip_category != blk.parskip_category)
                     ) {
                         llogo(blk, "Applying parskip %f in.", parskipI);
@@ -461,7 +461,7 @@ namespace My {
         };
 
         /** Get the type to use for a list item at a particular level */
-        private IndentType get_indent_for_level(uint level, bool is_bullet)
+        private IndentType get_indent_type_for_level(uint level, bool is_bullet)
         {
             unowned IndentType[] defns = is_bullet ? indentation_levels_bullets :
                 indentation_levels_numbers;
@@ -469,7 +469,12 @@ namespace My {
             return defns[level];
         }
 
-        /** The rendering state */
+        /**
+         * The rendering state.
+         *
+         * TODO move the per-level items into a helper class, and add a
+         * current_level accessor.
+         */
         private class State {
             /** Do not change \n to ' ' if true */
             public bool obeylines = false;
@@ -487,11 +492,27 @@ namespace My {
              */
             public uint[] last_numbers = {};
 
+            /**
+             * Left margins of content, in Pango units.
+             *
+             * The left margin of content in each level, or 0 if none.
+             */
+            public int[] content_lmarginsP = {};
+
+            /**
+             * Left margins of bullets/numbers, in Pango units.
+             *
+             * The left margin of the bullet/number in each level, or 0 if none.
+             */
+            public int[] bullet_lmarginsP = {};
+
             public State clone() {
                 var retval = new State();
                 retval.obeylines = obeylines;
                 retval.levels = levels;     // duplicates the array
                 retval.last_numbers = last_numbers;
+                retval.content_lmarginsP = content_lmarginsP;
+                retval.bullet_lmarginsP = bullet_lmarginsP;
                 return retval;
             }
         } // class State
@@ -600,7 +621,12 @@ namespace My {
 
             case BLOCK_QUOTE:
                 commit(blk, retval);
-                blk = new QuoteBlk(layout_, i2p(0.5));
+                int marginP = i2p(0.5); // text is indented 0.5" past marker
+                if(state.levels.length > 0) {
+                    var lidx = state.levels.length - 1;
+                    marginP += state.content_lmarginsP[lidx];
+                }
+                blk = new QuoteBlk(layout_, marginP);
                 sb.append(text_markup);
                 complete = true;
                 break;
@@ -614,10 +640,20 @@ namespace My {
                 state = state.clone();
 
                 // Add the indentation level
-                var indent = get_indent_for_level(state.levels.length,
-                        el.ty == BLOCK_BULLET_LIST);
-                state.levels += indent;
+                var is_bullet = el.ty == BLOCK_BULLET_LIST;
+                var indent_type = get_indent_type_for_level(state.levels.length,
+                        is_bullet);
+                state.levels += indent_type;
+                var lidx = state.levels.length - 1;
                 state.last_numbers += 0;
+
+                // TODO? change this?
+                int marginC = is_bullet ? 18 : 36;
+                state.content_lmarginsP += c2p((lidx+1)*marginC);
+                state.bullet_lmarginsP += c2p(lidx*marginC);
+                llogo(blk, "Now in lidx %d with indent type %s, bullet lmarg %f, content lmarg %f",
+                    lidx, indent_type.to_string(), p2i(state.bullet_lmarginsP[lidx]),
+                    p2i(state.content_lmarginsP[lidx]));
                 break;
 
             case BLOCK_LIST_ITEM:
@@ -625,15 +661,12 @@ namespace My {
                 var lidx = state.levels.length - 1;
                 state.last_numbers[lidx]++;
 
-                // TODO? change this?
-                int margin = state.levels[lidx].is_bullet() ? 18 : 36;
-
                 blk = new BulletBlk(layout_, bullet_layout_, "%s%s".printf(
                             state.levels[lidx].render(state.last_numbers[lidx]),
                             state.levels[lidx].is_bullet() ? "" : "."
                         ),
-                        Pango.SCALE * (lidx*margin),   // bullet_leftP
-                        Pango.SCALE * (lidx*margin + margin) // text_leftP
+                        state.bullet_lmarginsP[lidx],
+                        state.content_lmarginsP[lidx]
                 );
                 sb.append(text_markup);
 
@@ -649,7 +682,13 @@ namespace My {
 
             case BLOCK_CODE:
                 commit(blk, retval);
-                blk = new CodeBlk(layout_, i2p(0.25));
+
+                int marginP = 0;
+                if(state.levels.length > 0) {
+                    var lidx = state.levels.length - 1;
+                    marginP = state.content_lmarginsP[lidx];
+                }
+                blk = new CodeBlk(layout_, marginP, i2p(0.25));
 
                 state = state.clone();
 

--- a/src/writer/pango-markup.vala
+++ b/src/writer/pango-markup.vala
@@ -234,7 +234,7 @@ namespace My {
             linfoo(this, "Beginning rendering");
             foreach(var blk in blocks) {
                 if(blk.is_void()) {
-                    ldebugo(blk, "skipping void block");
+                    llogo(blk, "skipping void block");
                     continue;
                 }
 
@@ -255,12 +255,9 @@ namespace My {
                         "differs from prevblk category" : "no prev, or same as prev category"
                     );
 
-                    // FIXME: a document starting with a header gets parskip
-                    // before the header because of the empty block we left
-                    // right at the beginning.
-
                     if(!first_on_page_ && prev_blk != null &&
                         ( blk.parskip_category == COPY ||
+                          blk.parskip_category == HEADER ||
                         prev_blk.parskip_category != blk.parskip_category)
                     ) {
                         llogo(blk, "Applying parskip %f in.", parskipI);

--- a/t/200-html-comment-and-text.md
+++ b/t/200-html-comment-and-text.md
@@ -1,0 +1,1 @@
+<!-- html comment-->and text

--- a/t/200-html-comment.md
+++ b/t/200-html-comment.md
@@ -1,0 +1,1 @@
+<!-- html comment-->

--- a/t/200-md4c-reader-t.vala
+++ b/t/200-md4c-reader-t.vala
@@ -302,6 +302,32 @@ void test_image()
         default_node_checker, scheck);
 }
 
+void test_html_comment()
+{
+    diag(GLib.Log.METHOD);
+    read_and_test("200-html-comment.md", (doc)=> {
+        unowned GLib.Node<Elem> node0 = doc.root.nth_child(0);
+        assert_nonnull(node0);
+        if(node0 == null) {
+            return; // can't test anything else
+        }
+        assert_true(node0.n_children() == 0);
+    }, false);
+}
+
+// NOTE: if md4c-reader ever learns how to process HTML, change this test.
+void test_html_comment_and_text()
+{
+    diag(GLib.Log.METHOD);
+    read_and_test("200-html-comment-and-text.md", (doc)=> {
+        unowned GLib.Node<Elem> node0 = doc.root.nth_child(0);
+        assert_nonnull(node0);
+        if(node0 == null) {
+            return; // can't test anything else
+        }
+        assert_true(node0.n_children() == 0);
+    }, false);
+}
 public static int main (string[] args)
 {
     // run the tests
@@ -325,6 +351,8 @@ public static int main (string[] args)
     Test.add_func("/200-md4c-reader/strike", test_strike);
     Test.add_func("/200-md4c-reader/underline", test_underline);
     Test.add_func("/200-md4c-reader/image", test_image);
+    Test.add_func("/200-md4c-reader/html_comment", test_html_comment);
+    Test.add_func("/200-md4c-reader/html_comment_and_text", test_html_comment_and_text);
 
     return Test.run();
 }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -32,8 +32,10 @@ dist_test_data = \
 	060-headfoot-markup.pfft \
 	060-no-magic.pfft \
 	200-codeblock.md \
-	200-image.md \
+	200-html-comment-and-text.md \
+	200-html-comment.md \
 	200-image-bad.md \
+	200-image.md \
 	200-special.md \
 	200-special-nocmd.md \
 	basic.md \

--- a/t/complex.md
+++ b/t/complex.md
@@ -34,6 +34,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
          1. triply-nested
             1. 4x
                1. 5x Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+               2. Another 5x.  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
                   ```
                   A deeply-nested code block
                   ```

--- a/t/complex.md
+++ b/t/complex.md
@@ -34,6 +34,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
          1. triply-nested
             1. 4x
                1. 5x Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                  ```
+                  A deeply-nested code block
+                  ```
             1. 4x again
          1. 3x again
       1. doubly-nested third


### PR DESCRIPTION
### Added

- A changelog!
- Special blocks are now supported in core (#7)
- md4c-reader: special blocks can themselves include Markdown (#23)
- You can now use HTML comments in your Markdown files --- md4c-reader
  and pango-markup cooperate to remove those comments from the output (#28)

### Fixed

- pango-markup: Code blocks within bulleted or numbered lists are indented
- pango-markup: Consecutive headers have whitespace between them (#29)
